### PR TITLE
Update docker-compose.yml to use env_file for environment variables

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,14 +4,12 @@ services:
     container_name: postgres
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-postgres}"]
       interval: 10s
       timeout: 5s
       retries: 5
-    environment:
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
+    env_file:
+      - ../.env
     ports:
       - "5432:5432"
     volumes:
@@ -32,11 +30,8 @@ services:
     ports:
       - "9060:8000"
     environment:
-      DATABASE_URL: ${DATABASE_URL}
-      SECRET_KEY: ${SECRET_KEY}
-      DEBUG: ${DEBUG:-false}
-      APP_HOST: ${APP_HOST:-0.0.0.0}
-      APP_PORT: ${APP_PORT:-8000}
+      POSTGRES_HOST: db
+      POSTGRES_PORT: 5432
     env_file:
       - ../.env
     depends_on:


### PR DESCRIPTION
This will fix the `FATAL: database "appuser" does not exist` error, plus let you set your own variables in the .env file.